### PR TITLE
Remove server fingerprinting and normalize extensions list

### DIFF
--- a/rust-src/src/cache.rs
+++ b/rust-src/src/cache.rs
@@ -4,7 +4,7 @@ use std::collections::{HashSet, HashMap};
 use std::mem;
 use common::{Flow, ConnectionIPv6, ConnectionIPv4, u8_to_u16_be, u8_to_u32_be, u8array_to_u32_be};
 use std::net::IpAddr;
-use tls_parser::{ClientHelloFingerprint, ServerHelloFingerprint};
+use tls_parser::{ClientHelloFingerprint};
 
 // to ease load on db, cache queries
 pub struct MeasurementCache {
@@ -14,11 +14,6 @@ pub struct MeasurementCache {
     // (cid, timestamp): count
     fingerprints_new: HashMap<i64, ClientHelloFingerprint>,
     fingerprints_flushed: HashSet<i64>,
-    // for ServerHello
-    smeasurements: HashMap<(i64, i64), i32>,
-    // (cid, sid): count
-    sfingerprints_new: HashMap<i64, ServerHelloFingerprint>,
-    sfingerprints_flushed: HashSet<i64>,
     // for connections
 
     ticket_sizes: HashMap<(i64, i16), i64>, // (ClientHelloID, ticket_size) -> count
@@ -38,10 +33,6 @@ impl MeasurementCache {
             measurements: HashMap::new(),
             fingerprints_flushed: HashSet::new(),
             fingerprints_new: HashMap::new(),
-
-            smeasurements: HashMap::new(),
-            sfingerprints_flushed: HashSet::new(),
-            sfingerprints_new: HashMap::new(),
 
             ticket_sizes: HashMap::new(),
 
@@ -63,22 +54,10 @@ impl MeasurementCache {
         }
     }
 
-    pub fn add_smeasurement(&mut self, cid: i64, sid: i64) {
-        let key = (cid, sid);
-        let counter = self.smeasurements.entry(key).or_insert(0);
-        *counter += 1;
-    }
-
     pub fn add_ticket_size(&mut self, cid: i64, ticket_size: i16) {
         let key = (cid, ticket_size);
         let counter = self.ticket_sizes.entry(key).or_insert(0);
         *counter += 1;
-    }
-
-    pub fn add_sfingerprint(&mut self, sid: i64, fp: ServerHelloFingerprint) {
-        if !self.sfingerprints_flushed.contains(&sid) {
-            self.sfingerprints_new.insert(sid, fp);
-        }
     }
 
     pub fn add_connection(&mut self, flow: &Flow, cid: i64, sni: Vec<u8>, time_sec: i64) {
@@ -132,39 +111,6 @@ impl MeasurementCache {
         }
     }
 
-    pub fn update_connection_with_sid(&mut self, flow: &Flow, sid: i64) {
-        match flow.src_ip {
-            IpAddr::V4(_) => {
-                match flow.dst_ip {
-                    IpAddr::V4(_) => {
-                        match self.ipv4_connections.get_mut(&flow) {
-                            Some(mut conn) => conn.sid = sid,
-                            _ => {}
-                        }
-                    }
-                    IpAddr::V6(_) => {
-                        println!("[WARNING] IP versions mismatch! source(ipv4): {}, destination(ipv6): {}",
-                                 flow.src_ip, flow.dst_ip);
-                    }
-                }
-            }
-            IpAddr::V6(_) => {
-                match flow.dst_ip {
-                    IpAddr::V6(_) => {
-                        match self.ipv6_connections.get_mut(&flow) {
-                            Some(conn) => conn.sid = sid,
-                            _ => {}
-                        }
-                    }
-                    IpAddr::V4(_) => {
-                        println!("[WARNING] IP versions mismatch! source(ipv6): {}, destination(ipv4): {}",
-                                 flow.src_ip, flow.dst_ip);
-                    }
-                }
-            }
-        }
-    }
-
     // returns cached HashMap of measurements, empties it in object
     pub fn flush_measurements(&mut self) -> HashMap<(i64, i32), i32> {
         self.last_flush = time::now();
@@ -178,21 +124,6 @@ impl MeasurementCache {
             self.fingerprints_flushed.insert(*fp_id);
         }
         mem::replace(&mut self.fingerprints_new, HashMap::new())
-    }
-
-    // returns cached HashMap of measurements, empties it in object
-    pub fn flush_smeasurements(&mut self) -> HashMap<(i64, i64), i32> {
-        self.last_flush = time::now();
-        mem::replace(&mut self.smeasurements, HashMap::new())
-    }
-
-    // returns cached HashMap of fingerprints, empties it in object
-    pub fn flush_sfingerprints(&mut self) -> HashMap<i64, ServerHelloFingerprint> {
-        self.last_flush = time::now();
-        for (sid, _) in self.sfingerprints_new.iter() {
-            self.sfingerprints_flushed.insert(*sid);
-        }
-        mem::replace(&mut self.sfingerprints_new, HashMap::new())
     }
 
     fn get_ipv4connections_to_flush(&self) -> HashSet<Flow> {

--- a/rust-src/src/common.rs
+++ b/rust-src/src/common.rs
@@ -99,6 +99,13 @@ pub fn u8_to_u16_be(first_byte: u8, second_byte: u8) -> u16 {
     (first_byte as u16) << 8 | (second_byte as u16)
 }
 
+pub fn u16_to_u8_be(double: u16) -> Vec<u8> {
+    let mut res = Vec::new();
+    res.push((double >> 8) as u8);
+    res.push((double & 0x00ff) as u8);
+    res
+}
+
 pub fn u8_to_u32_be(first_byte: u8, second_byte: u8, third_byte: u8, forth_byte: u8) -> u32 {
     (first_byte as u32) << 24 | (second_byte as u32) << 16 | (third_byte as u32) << 8 |
         (forth_byte as u32)
@@ -114,6 +121,14 @@ pub fn vec_u8_to_vec_u16_be(a: &Vec<u8>) -> Vec<u16> {
     let mut result = Vec::with_capacity(a.len() / 2);
     for i in 0..result.capacity() {
         result.push(u8_to_u16_be(a[2 * i], a[2 * i + 1]));
+    }
+    result
+}
+
+pub fn vec_u16_to_vec_u8_be(a: &Vec<u16>) -> Vec<u8> {
+    let mut result = Vec::with_capacity(a.len() * 2);
+    for i in a {
+        result.append(&mut u16_to_u8_be(*i));
     }
     result
 }

--- a/rust-src/src/flow_tracker.rs
+++ b/rust-src/src/flow_tracker.rs
@@ -388,7 +388,7 @@ impl FlowTracker {
                 updated_rows = thread_db_conn.execute(&insert_fingerprint_norm_ext, &[
                     &(norm_ext_fp_id as i64),
                     &(fp.record_tls_version as i16), &(fp.ch_tls_version as i16),
-                    &fp.cipher_suites, &fp.compression_methods, &fp.extensions,
+                    &fp.cipher_suites, &fp.compression_methods, &fp.extensions_norm,
                     &fp.named_groups, &fp.ec_point_fmt, &fp.sig_algs, &fp.alpn,
                     &fp.key_share, &fp.psk_key_exchange_modes, &fp.supported_versions,
                     &fp.cert_compression_algs, &fp.record_size_limit,

--- a/rust-src/src/flow_tracker.rs
+++ b/rust-src/src/flow_tracker.rs
@@ -13,7 +13,7 @@ use pnet::packet::{Packet};
 use std::ops::Sub;
 
 use std::time::{Duration, Instant};
-use tls_parser::{ClientHelloFingerprint, ServerHelloFingerprint};
+use tls_parser::{ClientHelloFingerprint};
 use cache::{MeasurementCache, MEASUREMENT_CACHE_FLUSH};
 use stats_tracker::{StatsTracker};
 use common::{TimedFlow, Flow};
@@ -164,7 +164,7 @@ impl FlowTracker {
             match ClientHelloFingerprint::from_try(tcp_pkt.payload()) {
                 Ok(fp) => {
                     self.stats.fingerprints_seen += 1;
-                    let fp_id = fp.get_fingerprint();
+                    let fp_id = fp.get_fingerprint(false);
 
                     self.begin_tracking_server_flow(&flow.reversed_clone(), fp_id as i64);
 
@@ -203,38 +203,11 @@ impl FlowTracker {
             self.tracked_flows.remove(&flow);
             return;
         }
-
-        // check for ServerHello
-        if !is_client && self.tracked_server_flows.contains_key(&flow) {
-            self.stats.sfingerprint_checks += 1;
-            match ServerHelloFingerprint::from_try(tcp_pkt.payload()) {
-                Ok(fp) => {
-                    self.stats.sfingerprints_seen += 1;
-                    let sid = fp.get_fingerprint() as i64;
-                    let cid = self.tracked_server_flows[&flow];
-
-                    if self.write_to_stdout {
-                        println!("ServerHello: {{ sid: {} cid: {} fp: {}}}",
-                                 sid, cid, fp);
-                    }
-
-                    if self.write_to_db {
-                        self.cache.add_sfingerprint(sid, fp);
-                        self.cache.add_smeasurement(cid, sid);
-                        self.cache.update_connection_with_sid(&flow.reversed_clone(), sid);
-                    }
-                }
-                Err(_err) => {}
-            }
-            self.tracked_server_flows.remove(&flow);
-        }
     }
 
     fn flush_to_db(&mut self) {
         let client_mcache = self.cache.flush_measurements();
         let client_fcache = self.cache.flush_fingerprints();
-        let server_mcache = self.cache.flush_smeasurements();
-        let server_fcache = self.cache.flush_sfingerprints();
         let c4cache = self.cache.flush_ipv4connections();
         let c6cache = self.cache.flush_ipv6connections();
         let ticket_sizes = self.cache.flush_ticket_sizes();
@@ -244,25 +217,93 @@ impl FlowTracker {
             let inserter_thread_start = time::now();
             let mut thread_db_conn = Client::connect(&dsn, NoTls).unwrap();
 
-            // TODO: format these strings to match indentation
-            let insert_fingerprint = match thread_db_conn.prepare("INSERT
-INTO fingerprints (id, record_tls_version, ch_tls_version, cipher_suites, compression_methods, extensions, named_groups, ec_point_fmt, sig_algs, alpn,
-key_share, psk_key_exchange_modes, supported_versions, cert_compression_algs, record_size_limit)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-$11, $12, $13, $14, $15)
-ON CONFLICT (id) DO NOTHING;") {
+            let insert_fingerprint_original = match thread_db_conn.prepare(
+                "INSERT
+                INTO fingerprints (
+                    id,
+                    record_tls_version,
+                    ch_tls_version,
+                    cipher_suites,
+                    compression_methods,
+                    extensions,
+                    named_groups,
+                    ec_point_fmt,
+                    sig_algs,
+                    alpn,
+                    key_share,
+                    psk_key_exchange_modes,
+                    supported_versions,
+                    cert_compression_algs,
+                    record_size_limit
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+                ON CONFLICT (id) DO NOTHING;"
+            ) {
                 Ok(stmt) => stmt,
                 Err(e) => {
-                    println!("Preparing insert_fingerprint failed: {}", e);
+                    println!("Preparing insert_fingerprint_original failed: {}", e);
                     return;
                 }
             };
 
-            let insert_measurement = match thread_db_conn.prepare("INSERT
-INTO measurements (unixtime, id, count)
-VALUES ($1, $2, $3)
-ON CONFLICT ON CONSTRAINT measurements_pkey1 DO UPDATE
-  SET count = measurements.count + $4;") {
+            let insert_fingerprint_norm_ext = match thread_db_conn.prepare(
+                "INSERT
+                INTO fingerprints_norm_ext (
+                    id,
+                    record_tls_version,
+                    ch_tls_version,
+                    cipher_suites,
+                    compression_methods,
+                    normalized_extensions,
+                    named_groups,
+                    ec_point_fmt,
+                    sig_algs,
+                    alpn,
+                    key_share,
+                    psk_key_exchange_modes,
+                    supported_versions,
+                    cert_compression_algs,
+                    record_size_limit
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+                ON CONFLICT (id) DO NOTHING;"
+            ) {
+                Ok(stmt) => stmt,
+                Err(e) => {
+                    println!("Preparing insert_fingerprint_norm_ext failed: {}", e);
+                    return;
+                }
+            };
+
+            let insert_fingerprint_mapping = match thread_db_conn.prepare(
+                "INSERT
+                INTO fingerprint_map (
+                    id,
+                    norm_ext_id,
+                    extensions
+                )
+                VALUES ($1, $2, $3)
+                ON CONFLICT ON CONSTRAINT fingerprint_map_pkey DO UPDATE
+                SET count = fingerprint_map.count + 1;"
+            ) {
+                Ok(stmt) => stmt,
+                Err(e) => {
+                    println!("Preparing insert_fingerprint_map failed: {}", e);
+                    return;
+                }
+            };
+
+            let insert_measurement = match thread_db_conn.prepare(
+                "INSERT
+                INTO measurements (
+                    unixtime,
+                    id,
+                    count
+                )
+                VALUES ($1, $2, $3)
+                ON CONFLICT ON CONSTRAINT measurements_pkey1 DO UPDATE
+                SET count = measurements.count + $4;"
+            ) {
                 Ok(stmt) => stmt,
                 Err(e) => {
                     println!("Preparing insert_measurement failed: {}", e);
@@ -270,33 +311,18 @@ ON CONFLICT ON CONSTRAINT measurements_pkey1 DO UPDATE
                 }
             };
 
-            let insert_sfingerprint = match thread_db_conn.prepare("INSERT
-INTO sfingerprints (id, record_tls_version, sh_tls_version, cipher_suite, compression_method, extensions, eliptic_curves, ec_point_fmt, alpn)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-ON CONFLICT (id) DO NOTHING;") {
-                Ok(stmt) => stmt,
-                Err(e) => {
-                    println!("Preparing insert_sfingerprint failed: {}", e);
-                    return;
-                }
-            };
-
-            let insert_smeasurement = match thread_db_conn.prepare("INSERT
-INTO smeasurements (cid, sid, count)
-VALUES ($1, $2, $3)
-ON CONFLICT ON CONSTRAINT smeasurements_pkey DO UPDATE
-  SET count = smeasurements.count + $4;") {
-                Ok(stmt) => stmt,
-                Err(e) => {
-                    println!("Preparing insert_smeasurement failed: {}", e);
-                    return;
-                }
-            };
-
-            let insert_ipv4conn = match thread_db_conn.prepare("INSERT
-INTO ipv4connections (id, sid, anon_cli_ip, server_ip, SNI)
-VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT DO NOTHING;") {
+            let insert_ipv4conn = match thread_db_conn.prepare(
+                "INSERT
+                INTO ipv4connections (
+                    id,
+                    sid,
+                    anon_cli_ip,
+                    server_ip,
+                    SNI
+                )
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT DO NOTHING;"
+            ) {
                 Ok(stmt) => stmt,
                 Err(e) => {
                     println!("Preparing insert_ipv4conn failed: {}", e);
@@ -304,10 +330,18 @@ ON CONFLICT DO NOTHING;") {
                 }
             };
 
-            let insert_ipv6conn = match thread_db_conn.prepare("INSERT
-INTO ipv6connections (id, sid, anon_cli_ip, server_ip, SNI)
-VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT DO NOTHING;") {
+            let insert_ipv6conn = match thread_db_conn.prepare(
+                "INSERT
+                INTO ipv6connections (
+                    id,
+                    sid,
+                    anon_cli_ip,
+                    server_ip,
+                    SNI
+                )
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT DO NOTHING;"
+            ) {
                 Ok(stmt) => stmt,
                 Err(e) => {
                     println!("Preparing insert_ipv6conn failed: {}", e);
@@ -315,11 +349,17 @@ ON CONFLICT DO NOTHING;") {
                 }
             };
 
-            let insert_ticket_size = match thread_db_conn.prepare("INSERT
-INTO ticket_sizes (id, size, count)
-VALUES ($1, $2, $3)
-ON CONFLICT ON CONSTRAINT ticket_sizes_pkey DO UPDATE
-  SET count = ticket_sizes.count + $4;") {
+            let insert_ticket_size = match thread_db_conn.prepare(
+                "INSERT
+                INTO ticket_sizes (
+                    id,
+                    size,
+                    count
+                )
+                VALUES ($1, $2, $3)
+                ON CONFLICT ON CONSTRAINT ticket_sizes_pkey DO UPDATE
+                SET count = ticket_sizes.count + $4;"
+            ) {
                 Ok(stmt) => stmt,
                 Err(e) => {
                     println!("Preparing insert_ticket_size failed: {}", e);
@@ -328,14 +368,43 @@ ON CONFLICT ON CONSTRAINT ticket_sizes_pkey DO UPDATE
             };
 
             for (fp_id, fp) in client_fcache {
-                let updated_rows = thread_db_conn.execute(&insert_fingerprint, &[&(fp_id as i64),
+                // insert original signature
+                let mut updated_rows = thread_db_conn.execute(&insert_fingerprint_original, &[
+                    &(fp_id as i64),
                     &(fp.record_tls_version as i16), &(fp.ch_tls_version as i16),
                     &fp.cipher_suites, &fp.compression_methods, &fp.extensions,
                     &fp.named_groups, &fp.ec_point_fmt, &fp.sig_algs, &fp.alpn,
                     &fp.key_share, &fp.psk_key_exchange_modes, &fp.supported_versions,
-                    &fp.cert_compression_algs, &fp.record_size_limit,]);
+                    &fp.cert_compression_algs, &fp.record_size_limit,
+                ]);
                 if updated_rows.is_err() {
                     println!("Error updating fingerprints: {:?}", updated_rows);
+                }
+
+                // generate normalized extension fingerprint
+                let norm_ext_fp_id = fp.get_fingerprint(true);
+
+                // insert normalized extension list signature
+                updated_rows = thread_db_conn.execute(&insert_fingerprint_norm_ext, &[
+                    &(norm_ext_fp_id as i64),
+                    &(fp.record_tls_version as i16), &(fp.ch_tls_version as i16),
+                    &fp.cipher_suites, &fp.compression_methods, &fp.extensions,
+                    &fp.named_groups, &fp.ec_point_fmt, &fp.sig_algs, &fp.alpn,
+                    &fp.key_share, &fp.psk_key_exchange_modes, &fp.supported_versions,
+                    &fp.cert_compression_algs, &fp.record_size_limit,
+                ]);
+                if updated_rows.is_err() {
+                    println!("Error updating normalized extension fingerprints: {:?}", updated_rows);
+                }
+
+                // insert normalized vs original fingerprint mapping
+                updated_rows = thread_db_conn.execute(&insert_fingerprint_mapping, &[
+                    &(fp_id as i64),
+                    &(norm_ext_fp_id as i64),
+                    &fp.extensions,
+                ]);
+                if updated_rows.is_err() {
+                    println!("Error updating normalized extension fingerprints: {:?}", updated_rows);
                 }
             }
 
@@ -344,24 +413,6 @@ ON CONFLICT ON CONSTRAINT ticket_sizes_pkey DO UPDATE
                     &(count), &(count)]);
                 if updated_rows.is_err() {
                     println!("Error updating measurements: {:?}", updated_rows);
-                }
-            }
-
-            for (sid, fp) in server_fcache {
-                let updated_rows = thread_db_conn.execute(&insert_sfingerprint, &[&(sid as i64),
-                    &(fp.record_tls_version as i16), &(fp.sh_tls_version as i16),
-                    &(fp.cipher_suite as i16), &(fp.compression_method as i8), &fp.extensions,
-                    &fp.elliptic_curves, &fp.ec_point_fmt, &fp.alpn]);
-                if updated_rows.is_err() {
-                    println!("Error updating sfingerprints: {:?}", updated_rows);
-                }
-            }
-
-            for (k, count) in server_mcache {
-                let updated_rows = thread_db_conn.execute(&insert_smeasurement, &[&(k.0), &(k.1),
-                    &(count), &(count)]);
-                if updated_rows.is_err() {
-                    println!("Error updating smeasurements: {:?}", updated_rows);
                 }
             }
 

--- a/rust-src/src/tls_parser.rs
+++ b/rust-src/src/tls_parser.rs
@@ -10,7 +10,7 @@ use self::crypto::digest::Digest;
 use self::crypto::sha1::Sha1;
 use self::byteorder::{ByteOrder, BigEndian};
 
-use common::{u8_to_u16_be, u8_to_u32_be, vec_u8_to_vec_u16_be, hash_u32, HelloParseError};
+use common::{u8_to_u16_be, u8_to_u32_be, vec_u8_to_vec_u16_be, vec_u16_to_vec_u8_be, hash_u32, HelloParseError};
 
 enum_from_primitive! {
 #[repr(u8)]
@@ -217,6 +217,7 @@ impl ClientHelloFingerprint {
                 None => return Err(HelloParseError::ExtensionLenExceedBuf),
             };
         }
+        ch.sort_extensions();
         Ok(ch)
     }
 
@@ -298,9 +299,13 @@ impl ClientHelloFingerprint {
         };
 
         self.extensions.append(&mut ungrease_u8(ext_id_u8));
-        self.extensions_norm.append(&mut ungrease_u8(ext_id_u8));
-        self.extensions_norm.sort();
         Ok(())
+    }
+
+    pub fn sort_extensions(&mut self) {
+        let mut extensions = vec_u8_to_vec_u16_be(&self.extensions);
+        extensions.sort();
+        self.extensions_norm = vec_u16_to_vec_u8_be(&extensions);
     }
 
     pub fn get_fingerprint(&self, normalized_ext: bool) -> u64 {

--- a/rust-src/src/tls_parser.rs
+++ b/rust-src/src/tls_parser.rs
@@ -94,6 +94,7 @@ pub struct ClientHelloFingerprint {
     pub compression_methods: Vec<u8>,
 
     pub extensions: Vec<u8>,
+    pub extensions_norm: Vec<u8>,
     pub named_groups: Vec<u8>,
     pub ec_point_fmt: Vec<u8>,
     pub sig_algs: Vec<u8>,
@@ -187,6 +188,7 @@ impl ClientHelloFingerprint {
             cipher_suites: cipher_suites,
             compression_methods: compression_methods,
             extensions: Vec::new(),
+            extensions_norm: Vec::new(),
             named_groups: Vec::new(),
             ec_point_fmt: Vec::new(),
             sig_algs: Vec::new(),
@@ -296,10 +298,12 @@ impl ClientHelloFingerprint {
         };
 
         self.extensions.append(&mut ungrease_u8(ext_id_u8));
+        self.extensions_norm.append(&mut ungrease_u8(ext_id_u8));
+        self.extensions_norm.sort();
         Ok(())
     }
 
-    pub fn get_fingerprint(&self) -> u64 {
+    pub fn get_fingerprint(&self, normalized_ext: bool) -> u64 {
         //let mut s = DefaultHasher::new(); // This is SipHasher13, nobody uses this...
         //let mut s = SipHasher24::new_with_keys(0, 0);
         // Fuck Rust's deprecated "holier than thou" bullshit attitude
@@ -316,8 +320,13 @@ impl ClientHelloFingerprint {
         hash_u32(&mut hasher, self.compression_methods.len() as u32);
         hasher.input(&self.compression_methods);
 
-        hash_u32(&mut hasher, self.extensions.len() as u32);
-        hasher.input(&self.extensions);
+        if normalized_ext {
+            hash_u32(&mut hasher, self.extensions_norm.len() as u32);
+            hasher.input(&self.extensions_norm);
+        } else {
+            hash_u32(&mut hasher, self.extensions.len() as u32);
+            hasher.input(&self.extensions);
+        }
 
         hash_u32(&mut hasher, self.named_groups.len() as u32);
         hasher.input(&self.named_groups);
@@ -409,177 +418,6 @@ fn parse_key_share(arr: &[u8]) -> Result<Vec<u8>, HelloParseError> {
     Ok(res)
 }
 
-#[derive(Debug, PartialEq)]
-pub struct ServerHelloFingerprint {
-    pub record_tls_version: TlsVersion,
-    pub sh_tls_version: TlsVersion,
-    pub cipher_suite: u16,
-    pub compression_method: u8,
-
-    pub extensions: Vec<u8>,
-    pub elliptic_curves: Vec<u8>,
-    pub ec_point_fmt: Vec<u8>,
-    pub alpn: Vec<u8>,
-}
-
-
-pub type ServerHelloParseResult = Result<ServerHelloFingerprint, HelloParseError>;
-
-impl ServerHelloFingerprint {
-    pub fn from_try(a: &[u8]) -> ServerHelloParseResult {
-        if a.len() < 44 {
-            return Err(HelloParseError::ShortBuffer);
-        }
-
-        let record_type = a[0];
-        if TlsRecordType::from_u8(record_type) != Some(TlsRecordType::Handshake) {
-            return Err(HelloParseError::NotAHandshake);
-        }
-
-        let record_tls_version = match TlsVersion::from_u16(u8_to_u16_be(a[1], a[2])) {
-            Some(tls_version) => tls_version,
-            None => return Err(HelloParseError::UnknownRecordTLSVersion),
-        };
-
-        let record_length = u8_to_u16_be(a[3], a[4]);
-        if usize::from_u16(record_length).unwrap() > a.len() - 5 {
-            return Err(HelloParseError::ShortOuterRecord);
-        }
-
-        if TlsHandshakeType::from_u8(a[5]) != Some(TlsHandshakeType::ServerHello) {
-            return Err(HelloParseError::NotAServerHello);
-        }
-
-        let ch_length = u8_to_u32_be(0, a[6], a[7], a[8]);
-        if ch_length != record_length as u32 - 4 {
-            return Err(HelloParseError::InnerOuterRecordLenContradict);
-        }
-
-        let sh_tls_version = match TlsVersion::from_u16(u8_to_u16_be(a[9], a[10])) {
-            Some(tls_version) => tls_version,
-            None => return Err(HelloParseError::UnknownChTLSVersion),
-        };
-
-        // 32 bytes of client random
-
-        let mut offset: usize = 43;
-
-        let session_id_len = a[offset] as usize;
-        offset += session_id_len + 1;
-        if offset + 2 > a.len() {
-            return Err(HelloParseError::SessionIDLenExceedBuf);
-        }
-
-        if offset + 5 > a.len() {
-            return Err(HelloParseError::ShortBuffer);
-        }
-
-        let cipher_suite = u8_to_u16_be(a[offset], a[offset + 1]);
-        offset += 2;
-
-        let compression_method = a[offset];
-        offset += 1;
-
-        let extensions_len = u8_to_u16_be(a[offset], a[offset + 1]) as usize;
-        offset += 2;
-        if offset + extensions_len > a.len() {
-            return Err(HelloParseError::ExtensionsLenExceedBuf);
-        }
-
-        let mut sh = ServerHelloFingerprint {
-            record_tls_version: record_tls_version,
-            sh_tls_version: sh_tls_version,
-            cipher_suite: cipher_suite,
-            compression_method: compression_method,
-            extensions: Vec::new(),
-            elliptic_curves: Vec::new(),
-            ec_point_fmt: Vec::new(),
-            alpn: Vec::new(),
-        };
-
-        let sh_end = offset + extensions_len;
-        while offset < sh_end {
-            if offset > sh_end - 4 {
-                return Err(HelloParseError::ShortExtensionHeader);
-            }
-
-            let ext_len = u8_to_u16_be(a[offset + 2], a[offset + 3]) as usize;
-            if offset + ext_len > sh_end {
-                return Err(HelloParseError::ExtensionLenExceedBuf);
-            }
-            sh.process_extension(&a[offset..offset + 2], &a[offset + 4..offset + 4 + ext_len]);
-
-            offset = match (offset + 4).checked_add(ext_len) {
-                Some(i) => i,
-                None => return Err(HelloParseError::ExtensionLenExceedBuf),
-            };
-        }
-        Ok(sh)
-    }
-
-    // NOT UNGREASED
-    fn process_extension(&mut self, ext_id_u8: &[u8], ext_data: &[u8]) {
-        let ext_id = u8_to_u16_be(ext_id_u8[0], ext_id_u8[1]);
-        match TlsExtension::from_u16(ext_id) {
-            // we copy whole ext_data, including all the redundant lengths
-            Some(TlsExtension::SupportedCurves) => {
-                self.elliptic_curves = ext_data.to_vec();
-            }
-            Some(TlsExtension::SupportedPoints) => {
-                self.ec_point_fmt = ext_data.to_vec();
-            }
-            Some(TlsExtension::ALPN) => {
-                self.alpn = ext_data.to_vec();
-            }
-            _ => {}
-        };
-
-        self.extensions.append(&mut ungrease_u8(ext_id_u8));
-    }
-
-    pub fn get_fingerprint(&self) -> u64 {
-        let mut hasher = Sha1::new();
-
-        let versions = (self.record_tls_version as u32) << 16 | (self.sh_tls_version as u32);
-        hash_u32(&mut hasher, versions);
-
-        let suite_and_compr = (self.cipher_suite as u32) << 16 | (self.compression_method as u32);
-        // 8 bytes are left empty, that's fine
-        hash_u32(&mut hasher, suite_and_compr as u32);
-
-        hash_u32(&mut hasher, self.extensions.len() as u32);
-        hasher.input(&self.extensions);
-
-        hash_u32(&mut hasher, self.elliptic_curves.len() as u32);
-        hasher.input(&self.elliptic_curves);
-
-        hash_u32(&mut hasher, self.ec_point_fmt.len() as u32);
-        hasher.input(&self.ec_point_fmt);
-
-        hash_u32(&mut hasher, self.alpn.len() as u32);
-        hasher.input(&self.alpn);
-
-        let mut result = [0; 20];
-        hasher.result(&mut result);
-        BigEndian::read_u64(&result[0..8])
-    }
-}
-
-impl fmt::Display for ServerHelloFingerprint {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "record: {:?} sh: {:?} cipher: {:X} compression: {:X} \
-        extensions: {:X} curves: {:X} ec_fmt: {:X} alpn: {:X}",
-               self.record_tls_version, self.sh_tls_version,
-               &self.cipher_suite,
-               &self.compression_method,
-               vec_u8_to_vec_u16_be(&self.extensions).as_slice().as_hex(),
-               vec_u8_to_vec_u16_be(&self.elliptic_curves).as_slice().as_hex(),
-               self.ec_point_fmt.as_slice().as_hex(),
-               self.alpn.as_slice().as_hex(),
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use tls_parser::{ClientHelloFingerprint, TlsVersion};
@@ -602,6 +440,7 @@ mod tests {
             cipher_suites: Vec::new(),
             compression_methods: Vec::new(),
             extensions: Vec::new(),
+            extensions_norm: Vec::new(),
             named_groups: Vec::new(),
             ec_point_fmt: Vec::new(),
             sig_algs: Vec::new(),
@@ -614,7 +453,7 @@ mod tests {
             cert_compression_algs: Vec::new(),
             record_size_limit: Vec::new(),
         };
-        assert_eq!(ch.get_fingerprint(), 6116981759083077708);
+        assert_eq!(ch.get_fingerprint(false), 6116981759083077708);
     }
 
 
@@ -632,6 +471,7 @@ mod tests {
                              0x00, 0x23, 0x00, 0x0d, 0x00, 0x05, 0x00, 0x12,
                              0x00, 0x10, 0x75, 0x50, 0x00, 0x0b, 0x00, 0x0a,
                              0x0a, 0x0a],
+            extensions_norm: vec! [],
             named_groups: vec![0x00, 0x08, 0x0a, 0x0a, 0x00, 0x1d, 0x00, 0x17,
                                0x00, 0x18],
             ec_point_fmt: vec![0x01, 0x00],
@@ -652,7 +492,7 @@ mod tests {
             cert_compression_algs: Vec::new(),
             record_size_limit: Vec::new(),
         };
-        assert_eq!(ch.get_fingerprint(), 2850294275305369904);
+        assert_eq!(ch.get_fingerprint(false), 2850294275305369904);
     }
 
     #[test]
@@ -669,6 +509,7 @@ mod tests {
             compression_methods: vec![0],
             extensions: vec![0x00, 0x00, 0x00, 0x05, 0x00, 0x0a, 0x00, 0x0b,
                              0x00, 0x0d, 0x00, 0x17, 0xff, 0x01],
+            extensions_norm: vec! [],
             named_groups: vec![0x00, 0x04, 0x00, 0x17, 0x00, 0x18],
             ec_point_fmt: vec![0x01, 0x00],
             sig_algs: vec![0x00, 0x0e, 0x04, 0x01, 0x05, 0x01, 0x02, 0x01,
@@ -704,6 +545,7 @@ mod tests {
                              0x00, 0x23, 0x00, 0x0d, 0x00, 0x05, 0x00, 0x12,
                              0x00, 0x10, 0x75, 0x50, 0x00, 0x0b, 0x00, 0x0a,
                              0x0a, 0x0a],
+            extensions_norm: vec! [],
             named_groups: vec![0x00, 0x08, 0x0a, 0x0a, 0x00, 0x1d, 0x00, 0x17,
                                0x00, 0x18],
             ec_point_fmt: vec![0x01, 0x00],

--- a/tools/conversion/Cargo.toml
+++ b/tools/conversion/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "conversion"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+postgres = "0.19.1"
+rust-crypto = "0.2.36"
+byteorder = "1.4.3"

--- a/tools/conversion/src/main.rs
+++ b/tools/conversion/src/main.rs
@@ -1,0 +1,208 @@
+
+
+use postgres::{Client, NoTls};
+use crypto::digest::Digest;
+use crypto::sha1::Sha1;
+use byteorder::{ByteOrder, BigEndian};
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut client = Client::connect("host=localhost user=postgres", NoTls)?;
+
+    for row in client.query(
+        "SELECT
+            id,
+            record_tls_version,
+            ch_tls_version,
+            cipher_suites,
+            compression_methods,
+            extensions,
+            named_groups,
+            ec_point_fmt,
+            sig_algs,
+            alpn,
+            key_share,
+            psk_key_exchange_modes,
+            supported_versions,
+            cert_compression_algs,
+            record_size_limit
+        FROM
+            fingerprints", 
+        &[]
+    )? {
+        let id: i64 = row.get(0);
+        let record_tls_version: i16 = row.get(1);
+        let ch_tls_version: i16 = row.get(2);
+        let cipher_suites_raw: Option<&[u8]> = row.get(3);
+        let cipher_suites: Vec<u8> = cipher_suites_raw.unwrap().to_vec();
+
+        let compression_methods_raw: Option<&[u8]> = row.get(4);
+        let compression_methods: Vec<u8> = compression_methods_raw.unwrap().to_vec();
+        let extensions_raw: Option<&[u8]> = row.get(5);
+        let extensions: Vec<u8> = extensions_raw.unwrap().to_vec();
+        let named_groups_raw: Option<&[u8]> = row.get(6);
+        let named_groups: Vec<u8> = named_groups_raw.unwrap().to_vec();
+        let ec_point_fmt_raw: Option<&[u8]> = row.get(7);
+        let ec_point_fmt: Vec<u8> = ec_point_fmt_raw.unwrap().to_vec();
+        let sig_algs_raw: Option<&[u8]> = row.get(8);
+        let sig_algs: Vec<u8> = sig_algs_raw.unwrap().to_vec();
+        let alpn_raw: Option<&[u8]> = row.get(9);
+        let alpn: Vec<u8> = alpn_raw.unwrap().to_vec();
+        let key_share_raw: Option<&[u8]> = row.get(10);
+        let key_share: Vec<u8> = key_share_raw.unwrap().to_vec();
+        let psk_key_exchange_modes_raw: Option<&[u8]> = row.get(11);
+        let psk_key_exchange_modes: Vec<u8> = psk_key_exchange_modes_raw.unwrap().to_vec();
+        let supported_versions_raw: Option<&[u8]> = row.get(12);
+        let supported_versions: Vec<u8> = supported_versions_raw.unwrap().to_vec();
+        let cert_compression_algs_raw: Option<&[u8]> = row.get(13);
+        let cert_compression_algs: Vec<u8> = cert_compression_algs_raw.unwrap().to_vec();
+        let record_size_limit_raw: Option<&[u8]> = row.get(14);
+        let record_size_limit: Vec<u8> = record_size_limit_raw.unwrap().to_vec();
+        let sorted_extensions: Vec<u8> = sort_extensions(&extensions);
+
+        let original_fingerprint = get_fingerprint(
+            record_tls_version,
+            ch_tls_version,
+            &cipher_suites,
+            &compression_methods,
+            &extensions,
+            &named_groups,
+            &ec_point_fmt,
+            &sig_algs,
+            &alpn,
+            &key_share,
+            &psk_key_exchange_modes,
+            &supported_versions,
+            &cert_compression_algs,
+            &record_size_limit,
+        );
+
+        let normalized_fingerprint = get_fingerprint(
+            record_tls_version,
+            ch_tls_version,
+            &cipher_suites,
+            &compression_methods,
+            &sorted_extensions,
+            &named_groups,
+            &ec_point_fmt,
+            &sig_algs,
+            &alpn,
+            &key_share,
+            &psk_key_exchange_modes,
+            &supported_versions,
+            &cert_compression_algs,
+            &record_size_limit,
+        );
+
+        println!("Recorded: {:?}, Original: {:?}, Normalized: {:?}", id, original_fingerprint, normalized_fingerprint);
+    }
+    Ok(())
+}
+
+
+pub fn get_fingerprint(
+    record_tls_version: i16,
+    ch_tls_version: i16,
+    cipher_suites: &Vec<u8>,
+    compression_methods: &Vec<u8>,
+    extensions: &Vec<u8>,
+    named_groups: &Vec<u8>,
+    ec_point_fmt: &Vec<u8>,
+    sig_algs: &Vec<u8>,
+    alpn: &Vec<u8>,
+    key_share: &Vec<u8>,
+    psk_key_exchange_modes: &Vec<u8>,
+    supported_versions: &Vec<u8>,
+    cert_compression_algs: &Vec<u8>,
+    record_size_limit: &Vec<u8>,
+) -> u64 {
+    //let mut s = DefaultHasher::new(); // This is SipHasher13, nobody uses this...
+    //let mut s = SipHasher24::new_with_keys(0, 0);
+    // Fuck Rust's deprecated "holier than thou" bullshit attitude
+    // We'll use SHA1 instead...
+
+    let mut hasher = Sha1::new();
+    let versions = (record_tls_version as u32) << 16 | (ch_tls_version as u32);
+    hash_u32(&mut hasher, versions);
+
+
+    hash_u32(&mut hasher, cipher_suites.len() as u32);
+    hasher.input(cipher_suites);
+
+    hash_u32(&mut hasher, compression_methods.len() as u32);
+    hasher.input(compression_methods);
+
+    hash_u32(&mut hasher, extensions.len() as u32);
+    hasher.input(extensions);
+
+    hash_u32(&mut hasher, named_groups.len() as u32);
+    hasher.input(named_groups);
+
+    hash_u32(&mut hasher, ec_point_fmt.len() as u32);
+    hasher.input(ec_point_fmt);
+
+    hash_u32(&mut hasher, sig_algs.len() as u32);
+    hasher.input(sig_algs);
+
+    hash_u32(&mut hasher, alpn.len() as u32);
+    hasher.input(alpn);
+
+    hash_u32(&mut hasher, key_share.len() as u32);
+    hasher.input(key_share);
+
+    hash_u32(&mut hasher, psk_key_exchange_modes.len() as u32);
+    hasher.input(psk_key_exchange_modes);
+
+    hash_u32(&mut hasher, supported_versions.len() as u32);
+    hasher.input(supported_versions);
+
+    hash_u32(&mut hasher, cert_compression_algs.len() as u32);
+    hasher.input(cert_compression_algs);
+
+    hash_u32(&mut hasher, record_size_limit.len() as u32);
+    hasher.input(record_size_limit);
+
+    let mut result = [0; 20];
+    hasher.result(&mut result);
+    BigEndian::read_u64(&result[0..8])
+}
+
+pub fn hash_u32<D: Digest>(h: &mut D, n: u32) {
+    h.input(&[((n >> 24) & 0xff) as u8,
+        ((n >> 16) & 0xff) as u8,
+        ((n >> 8) & 0xff) as u8,
+        (n & 0xff) as u8]);
+}
+
+pub fn u8_to_u16_be(first_byte: u8, second_byte: u8) -> u16 {
+    (first_byte as u16) << 8 | (second_byte as u16)
+}
+
+pub fn u16_to_u8_be(double: u16) -> Vec<u8> {
+    let mut res = Vec::new();
+    res.push((double >> 8) as u8);
+    res.push((double & 0x00ff) as u8);
+    res
+}
+
+pub fn vec_u8_to_vec_u16_be(a: &Vec<u8>) -> Vec<u16> {
+    let mut result = Vec::with_capacity(a.len() / 2);
+    for i in 0..result.capacity() {
+        result.push(u8_to_u16_be(a[2 * i], a[2 * i + 1]));
+    }
+    result
+}
+
+pub fn vec_u16_to_vec_u8_be(a: &Vec<u16>) -> Vec<u8> {
+    let mut result = Vec::with_capacity(a.len() * 2);
+    for i in a {
+        result.append(&mut u16_to_u8_be(*i));
+    }
+    result
+}
+
+pub fn sort_extensions(extensions_raw: &Vec<u8>) -> Vec<u8> {
+    let mut extensions = vec_u8_to_vec_u16_be(extensions_raw);
+    extensions.sort();
+    vec_u16_to_vec_u8_be(&extensions)
+}

--- a/tools/hyperloglog_insert/Cargo.toml
+++ b/tools/hyperloglog_insert/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "hyperloglog_insert"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+postgres = "0.19.1"

--- a/tools/hyperloglog_insert/src/main.rs
+++ b/tools/hyperloglog_insert/src/main.rs
@@ -4,8 +4,9 @@ use std::collections::HashMap;
 
 const HLL_REGS: usize = 128; // Number of registers for HLL struct
 const HLL_BITS: usize = 7; // log2(HLL_REGS)
-const MASK: u8 = (1<<(8-HLL_BITS)) - 1;
-const IDX_MASK: u8 = 0xff ^ MASK;
+const MASK: u64 = (1<<(8-HLL_BITS)) - 1;
+const IDX_MASK: u64 = 0xff ^ MASK;
+const H_MASK: u64 = !(IDX_MASK << 56);
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut norm_fp_counts = HashMap::new();
@@ -64,8 +65,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 fn update_norm_count(norm_fp_id: i64, h: i64, map: &mut HashMap<i64, [u8; HLL_REGS]>) {
     let estimate = map.entry(norm_fp_id).or_insert([0; HLL_REGS]); // Get existing estimate or insert new one
-    let idx = ((((h>>56) as u8) & IDX_MASK) >> (8-HLL_BITS)) as usize; //Get first byte of 8 byte fp AND with IDX_MASK
-    let masked_h = h & (((MASK as u64) << 56) as i64); //MASK the position bits in nor
+    let idx = ((((h as u64)>>56) & IDX_MASK) >> (8-HLL_BITS)) as usize; //Get first byte of 8 byte fp AND with IDX_MASK
+    let masked_h = h & H_MASK as i64; //MASK the position bits in nor
     let pos = (masked_h.leading_zeros() - (HLL_BITS as u32) + 1) as u8; // Remove initial positional bytes, increment by one for leading zeros count
     if pos > estimate[idx] {
         estimate[idx] = pos;

--- a/tools/hyperloglog_insert/src/main.rs
+++ b/tools/hyperloglog_insert/src/main.rs
@@ -1,0 +1,66 @@
+use postgres::{Client, NoTls};
+use std::error::Error;
+use std::collections::HashMap;
+
+const HLL_REGS: usize = 128; // Number of registers for HLL struct
+const HLL_BITS: usize = 7; // log2(HLL_REGS)
+const MASK: u8 = (1<<(8-HLL_BITS)) - 1;
+const IDX_MASK: u8 = 0xff ^ MASK;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut norm_fp_counts = HashMap::new();
+
+    let mut client = Client::connect("host=localhost user=postgres", NoTls)?;
+
+    let insert_fingerprint_count_est = match client.prepare(
+        "INSERT
+        INTO fingerprint_count_est (
+            norm_fp_id,
+            regs
+        )
+        VALUES ($1, $2)
+        ON CONFLICT (norm_fp_id) DO UPDATE
+        SET regs = greatest_bytea(fingerprint_count_est.regs, $1);"
+    ) {
+        Ok(stmt) => stmt,
+        Err(e) => {
+            println!("Preparing insert_fingerprint_count_est failed: {}", e);
+            return Err(Box::new(e))
+        }
+    };
+
+    for row in client.query(
+        "SELECT
+            id,
+            norm_ext_id
+        FROM
+            fingerprint_map", 
+        &[]
+    )? {
+        let id: i64 = row.get(0);
+        let norm_fp_id: i64 = row.get(1);
+
+        update_norm_count(norm_fp_id, id, &mut norm_fp_counts);
+    }
+    
+    for (norm_fp_id, regs) in norm_fp_counts {
+        let updated_rows = client.execute(&insert_fingerprint_count_est, &[
+            &(norm_fp_id),
+            &regs.to_vec(),
+        ]);
+        if updated_rows.is_err() {
+            println!("Error updating normalized extension fingerprints: {:?}", updated_rows);
+        }
+    }
+    Ok(())
+}
+
+fn update_norm_count(norm_fp_id: i64, h: i64, map: &mut HashMap<i64, [u8; HLL_REGS]>) {
+    let estimate = map.entry(norm_fp_id).or_insert([0; HLL_REGS]); // Get existing estimate or insert new one
+    let idx = ((((h>>56) as u8) & IDX_MASK) >> (8-HLL_BITS)) as usize; //Get first byte of 8 byte fp AND with IDX_MASK
+    let masked_h = h & (((MASK as u64) << 56) as i64); //MASK the position bits in nor
+    let pos = (masked_h.leading_zeros() - (HLL_BITS as u32) + 1) as u8; // Remove initial positional bytes, increment by one for leading zeros count
+    if pos > estimate[idx] {
+        estimate[idx] = pos;
+    }
+}

--- a/tools/psql/pfunc.c
+++ b/tools/psql/pfunc.c
@@ -1,3 +1,4 @@
+#include <math.h>
 
 #include "postgres.h"
 #include "fmgr.h"
@@ -314,4 +315,44 @@ greatest_bytea(PG_FUNCTION_ARGS)
 
     PG_RETURN_BYTEA_P(result);
     */
+}
+
+PG_FUNCTION_INFO_V1(hll_count);
+Datum
+hll_count(PG_FUNCTION_ARGS)
+{
+    bytea *arg1 = PG_GETARG_BYTEA_P(0);
+
+
+    uint8_t *regs = VARDATA(arg1);
+
+    size_t m = VARSIZE(arg1)-VARHDRSZ;
+
+
+    // a_m estimation from: https://en.wikipedia.org/wiki/HyperLogLog
+    int64_t a_m;
+
+    switch(m) {
+        case 16:
+            a_m = 0.673;
+            break;
+        case 32:
+            a_m = 0.697;
+            break;
+        case 64:
+            a_m = 0.709;
+            break;
+        default:
+            a_m = 0.7213 / (1+(1.079/m));
+    }
+    
+    int i;
+
+    int64_t z = 0;
+    for (i=0; i<m; i++) {
+        z += pow(2, -regs[1]);
+    }
+    z = 1.0 / z;
+    int64_t count = a_m * (m*m) * z;
+    PG_RETURN_INT64(count);
 }


### PR DESCRIPTION
This PR cleans up the code a little by removing deprecated server fingerprinting. It also adds a normalized extension list fingerprint that is inserted side by side with the existing database. Future work should remove the original server fingerprint database insert as original data can be derived from the new tables.